### PR TITLE
docs : issue template 생성

### DIFF
--- a/.github/ISSUE_TEMPLATE/default-template.md
+++ b/.github/ISSUE_TEMPLATE/default-template.md
@@ -1,0 +1,24 @@
+---
+name: Default template
+about: " type : Feature  , Improvement  , Bug"
+title: "[Default]"
+labels: ''
+assignees: ''
+
+---
+
+// Title
+{이슈 요약(대상 + 행동 like 페이지 구현)}
+
+// Content
+## Description
+
+{이슈 설명}
+
+## TO-DO
+
+- [ ] {할 일}
+
+## ETC
+
+{기타 내용}

--- a/.github/ISSUE_TEMPLATE/discussion-template.md
+++ b/.github/ISSUE_TEMPLATE/discussion-template.md
@@ -1,0 +1,24 @@
+---
+name: Discussion template
+about: " type : Discussion"
+title: "[Discussion]"
+labels: 'Type: Disscusion'
+assignees: ''
+
+---
+
+// Title
+{이슈 대상} 관련 논의
+
+// Content
+## Problem
+
+{문제 상황}
+
+## Goal
+
+{해결 목표}
+
+## Related Issue
+
+#{이슈 번호}


### PR DESCRIPTION
Issue 작성 시 자동으로 템플릿을 가져오도록 default와 discussion 두 가지의 Issue template를 생성함. 
자동화되기 때문에 형식 작성의 번거로움을 덜고, 오류를 방지 할 수 있음. 