### PR TITLE
레이아웃 구현

### DIFF
--- a/src/hooks/useNavState.js
+++ b/src/hooks/useNavState.js
@@ -1,0 +1,11 @@
+import { useState } from "react";
+import { useLocation } from "react-router-dom";
+
+export function useNavState() {
+  const currentUrl = useLocation()
+    .pathname.replace(/\d/, "")
+    .replace(/^\/+|\/+$/g, "");
+  const [selectedmainNav, setselectedMainNav] = useState("Watching");
+
+  return { currentUrl, selectedmainNav, setselectedMainNav };
+}

--- a/src/layouts/AuthCheck.jsx
+++ b/src/layouts/AuthCheck.jsx
@@ -1,10 +1,16 @@
-import { Outlet } from "react-router-dom";
+import { useEffect } from "react";
+import { Outlet, useNavigate } from "react-router-dom";
 
 export default function AuthCheck() {
-  return (
-    <>
-      <h1>AuthCheck</h1>
-      <Outlet />
-    </>
-  );
+  const navigate = useNavigate();
+
+  // React.StrictMode에서 실행 시 2번 동작하여 의도치 않은 효과가 발생함
+  useEffect(() => {
+    if (!window.localStorage.getItem("token"))
+      if (window.confirm("로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?"))
+        navigate("/login");
+      else navigate(-1);
+  });
+
+  return <Outlet />;
 }

--- a/src/layouts/GNB.jsx
+++ b/src/layouts/GNB.jsx
@@ -1,3 +1,135 @@
+import { useEffect, useState } from "react";
+import { useLocation, Link } from "react-router-dom";
+
+const nav = [
+  {
+    mainNav: "Watching",
+    mainUrl: "watching",
+    sub: [
+      { subNav: "Video", url: ["watching/videos", "watching/video"] },
+      { subNav: "History", url: ["watching/History"] },
+    ],
+  },
+  {
+    mainNav: "Mentoring",
+    mainUrl: "mentoring",
+    sub: [
+      {
+        subNav: "List",
+        url: [
+          "mentoring/posts",
+          "mentoring/post",
+          "mentoring/write",
+          "mentoring/edit",
+        ],
+      },
+      { subNav: "Dashboard", url: ["mentoring/dashboard"] },
+    ],
+  },
+  {
+    mainNav: "Chatting",
+    mainUrl: "chatting",
+    sub: [
+      {
+        subNav: "Open Chatting",
+        url: [
+          "chatting/rooms",
+          "chatting/roomprofile",
+          "chatting/room",
+          "chatting/create",
+        ],
+      },
+    ],
+  },
+  {
+    mainNav: "My Page",
+    mainUrl: "mypage",
+    sub: [
+      { subNav: "Profile", url: ["mypage/profile", "mypage/profile/fix"] },
+      {
+        subNav: "Information",
+        url: ["mypage/information", "mypage/information/fix"],
+      },
+    ],
+  },
+];
+
 export default function GNB() {
-  return <nav className="fixed top-0 w-full h-20 bg-white"></nav>;
+  const location = useLocation();
+  const crruentUrl = location.pathname
+    .replace(/\d/, "")
+    .replace(/^\/+|\/+$/g, "");
+  const [seletedMainNav, setSeletedMainNav] = useState("Watching");
+
+  const handleMainNavClick = (e) => {
+    setSeletedMainNav(e.target.innerText);
+  };
+
+  const handleNavMouseLeave = (e) => {
+    setSeletedMainNav(
+      nav.find((val) => val.mainUrl === crruentUrl.split("/")[0]).mainNav
+    );
+  };
+
+  useEffect(() => {
+    setSeletedMainNav(
+      nav.find((val) => val.mainUrl === crruentUrl.split("/")[0]).mainNav
+    );
+  }, [crruentUrl]);
+
+  return (
+    <nav
+      className="fixed top-0 w-full h-20 bg-white text-green-900"
+      onMouseLeave={handleNavMouseLeave}
+    >
+      {/* 상단 GNB */}
+      <div className="h-12 px-16 border flex items-center">
+        {/* 상단 Nav */}
+        <div className="flex-1 flex justify-start space-x-4">
+          {nav.map((val) => (
+            <button
+              key={`mainNav-${val.mainNav}`}
+              className={`w-20 h-7 text-center text-sm${
+                val.mainNav === seletedMainNav ? " font-bold" : ""
+              } ${
+                crruentUrl.includes(val.mainNav.toLowerCase().replace(" ", ""))
+                  ? " border-b-2 border-orange"
+                  : ""
+              }`}
+              onClick={handleMainNavClick}
+            >
+              {val.mainNav}
+            </button>
+          ))}
+        </div>
+        {/* 로고 */}
+        <div className="flex-1 flex justify-center">
+          <Link className="flex items-center" to="/watching/videos">
+            <span className="material-symbols-outlined">deceased</span>
+            <span className="text-lg font-semibold">Garden</span>
+          </Link>
+        </div>
+        {/* 계정 기능 */}
+        <div className="flex-1 flex justify-end space-x-4">
+          <div>로그인</div>
+        </div>
+      </div>
+      {/* 하단 GNB(Nav) */}
+      <div className="h-8 px-16 border space-x-4">
+        {nav
+          .find((val) => val.mainNav === seletedMainNav)
+          .sub.map((val) => (
+            <Link
+              key={`subNav-${val.subNav}`}
+              className={`text-xs${
+                val.url.includes(crruentUrl) ? " text-orange font-semibold" : ""
+              }`}
+              to={val.url[0]}
+            >
+              {val.subNav}
+            </Link>
+          ))}
+      </div>
+    </nav>
+  );
 }

--- a/src/layouts/GNB.jsx
+++ b/src/layouts/GNB.jsx
@@ -1,5 +1,7 @@
-import { useEffect, useState } from "react";
-import { useLocation, Link } from "react-router-dom";
+import { useEffect } from "react";
+import { Link } from "react-router-dom";
+
+import { useNavState } from "/src/hooks/useNavState.js";
 
 const nav = [
   {
@@ -55,44 +57,40 @@ const nav = [
 ];
 
 export default function GNB() {
-  const location = useLocation();
-  const crruentUrl = location.pathname
-    .replace(/\d/, "")
-    .replace(/^\/+|\/+$/g, "");
-  const [seletedMainNav, setSeletedMainNav] = useState("Watching");
-
-  const handleMainNavClick = (e) => {
-    setSeletedMainNav(e.target.innerText);
-  };
-
-  const handleNavMouseLeave = (e) => {
-    setSeletedMainNav(
-      nav.find((val) => val.mainUrl === crruentUrl.split("/")[0]).mainNav
-    );
-  };
+  const { currentUrl, selectedmainNav, setselectedMainNav } = useNavState();
 
   useEffect(() => {
-    setSeletedMainNav(
-      nav.find((val) => val.mainUrl === crruentUrl.split("/")[0]).mainNav
+    setselectedMainNav(
+      nav.find((val) => val.mainUrl === currentUrl.split("/")[0]).mainNav
     );
-  }, [crruentUrl]);
+  }, [setselectedMainNav, currentUrl]);
+
+  const handleNavMouseLeave = () => {
+    setselectedMainNav(
+      nav.find((val) => val.mainUrl === currentUrl.split("/")[0]).mainNav
+    );
+  };
+
+  const handleMainNavClick = (e) => {
+    setselectedMainNav(e.target.innerText);
+  };
 
   return (
     <nav
       className="fixed top-0 w-full h-20 bg-white text-green-900"
       onMouseLeave={handleNavMouseLeave}
     >
-      {/* 상단 GNB */}
+      {/* 상단GNB */}
       <div className="h-12 px-16 border flex items-center">
-        {/* 상단 Nav */}
+        {/* 상단GNB - 상단Nav */}
         <div className="flex-1 flex justify-start space-x-4">
           {nav.map((val) => (
             <button
               key={`mainNav-${val.mainNav}`}
               className={`w-20 h-7 text-center text-sm${
-                val.mainNav === seletedMainNav ? " font-bold" : ""
-              } ${
-                crruentUrl.includes(val.mainNav.toLowerCase().replace(" ", ""))
+                val.mainNav === selectedmainNav ? " font-bold" : ""
+              }${
+                currentUrl.includes(val.mainUrl)
                   ? " border-b-2 border-orange"
                   : ""
               }`}
@@ -102,14 +100,14 @@ export default function GNB() {
             </button>
           ))}
         </div>
-        {/* 로고 */}
+        {/* 상단GNB - 로고 */}
         <div className="flex-1 flex justify-center">
           <Link className="flex items-center" to="/watching/videos">
             <span className="material-symbols-outlined">deceased</span>
             <span className="text-lg font-semibold">Garden</span>
           </Link>
         </div>
-        {/* 계정 기능 */}
+        {/* 상단GNB - 계정 */}
         <div className="flex-1 flex justify-end space-x-4">
           <div>로그인</div>
         </div>
@@ -117,12 +115,12 @@ export default function GNB() {
       {/* 하단 GNB(Nav) */}
       <div className="h-8 px-16 border space-x-4">
         {nav
-          .find((val) => val.mainNav === seletedMainNav)
+          .find((val) => val.mainNav === selectedmainNav)
           .sub.map((val) => (
             <Link
               key={`subNav-${val.subNav}`}
               className={`text-xs${
-                val.url.includes(crruentUrl) ? " text-orange font-semibold" : ""
+                val.url.includes(currentUrl) ? " text-orange font-semibold" : ""
               }`}
               to={val.url[0]}
             >

--- a/src/layouts/GNB.jsx
+++ b/src/layouts/GNB.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 
 import { useNavState } from "/src/hooks/useNavState.js";
@@ -58,6 +58,13 @@ const nav = [
 
 export default function GNB() {
   const { currentUrl, selectedmainNav, setselectedMainNav } = useNavState();
+  // 로그인 기능 생기기 전까지 임시 로그인 판단 방식
+  const [auth, setAuth] = useState(
+    window.localStorage.getItem("token") ? true : false
+  );
+  // api 기능 생기기 전까지 임시 프로필 이미지 경로
+  const profileImageUrl =
+    "https://mblogthumb-phinf.pstatic.net/MjAyMDExMDFfMjIg/MDAxNjA0MjI4ODc1MDkx.itxFQbHQ_zAuNQJU7PCOlF0mmstYn2v4ZF4WygunqGIg.3jloNowx-eWU-ztCLACtYubVbATNdCFQLjgvYsynV1og.JPEG.gambasg/유튜브_기본프로필_주황.jpg?type=w400";
 
   useEffect(() => {
     setselectedMainNav(
@@ -73,6 +80,11 @@ export default function GNB() {
 
   const handleMainNavClick = (e) => {
     setselectedMainNav(e.target.innerText);
+  };
+
+  const handleLogOutClick = () => {
+    window.localStorage.removeItem("token");
+    setAuth(window.localStorage.getItem("token") ? true : false);
   };
 
   return (
@@ -108,8 +120,49 @@ export default function GNB() {
           </Link>
         </div>
         {/* 상단GNB - 계정 */}
-        <div className="flex-1 flex justify-end space-x-4">
-          <div>로그인</div>
+        <div className="flex-1 flex justify-end items-center space-x-4">
+          {auth ? (
+            <>
+              <div>
+                <img
+                  className="w-7 rounded-full"
+                  src={profileImageUrl}
+                  alt="기본 프로필 사진"
+                ></img>
+              </div>
+              <Link
+                className="pl-1 pr-2 py-[2px] border-2 border-orange rounded"
+                to={"/watching/videos"}
+                onClick={handleLogOutClick}
+              >
+                <span className=" flex items-center text-xs text-orange">
+                  <span className="material-symbols-outlined">logout</span>
+                  Log Out
+                </span>
+              </Link>
+            </>
+          ) : (
+            <Link
+              className="pl-1 pr-2 py-[2px] bg-orange border-2 border-orange rounded"
+              to={"/login"}
+            >
+              <span className="flex items-center text-xs text-white">
+                <span className="material-symbols-outlined">login</span>
+                <span className="px-1">Log In</span>
+              </span>
+            </Link>
+          )}
+          {/* 로그인 기능이 생기기 전까지 임시 로그인 */}
+          <div
+            className="px-2 py-1 bg-green-500 rounded text-xs text-white"
+            onClick={function () {
+              if (auth) window.localStorage.removeItem("token");
+              else window.localStorage.setItem("token", "Bearer 1234");
+              setAuth(window.localStorage.getItem("token") ? true : false);
+            }}
+          >
+            TEST
+          </div>
         </div>
       </div>
       {/* 하단 GNB(Nav) */}


### PR DESCRIPTION
## Summary

저번 PR(#15)에 이어 레이아웃을 구현함


## Details

#3 TO-DO

```
- 레이아웃 구조 작성
- 레이아웃 로직 구현
- 레이아웃 CSS 적용
- 계정 관련 로직 적용
```

- 내비 계층을 구조화한 nav 배열을 토대로 내비게이션을 구현함
- 내비게이션을 제어하기 위해 사용한 값들을 하나의 상태로 묶어
  useNavState 커스텀훅으로 분리함
- 로그인 기능 구현 전이므로
  로컬스토리지 내 token 유무로 로그인 상태 판별이 가능하다고 가정하고,
  임시로 로그인용 TEST 버튼을 두었음
- api 기능 구현 전이므로
  이미지의 경우 response에서 이미지 url을 준다고 가정함

![image](https://github.com/Step3-kakao-tech-campus/Team18_FE/assets/81379968/7707909b-db9f-4651-8a02-9a5493dc84f2)
![image](https://github.com/Step3-kakao-tech-campus/Team18_FE/assets/81379968/27567829-c52d-4624-bdf3-6933694fbba3)

- 로그인이 필요한 페이지에 접근할 때 로그인이 안되어 있으면
  로그인 페이지으로 가거나 이전 페이지로 돌아가도록 구현함
- React.StrictMode 상에서 실행할 경우 useEffect가 2번 동작하므로
  AuthCheck에서 실제 배포와는 다르게 의도치 못한 효과가 발생할 수 있음

![image](https://github.com/Step3-kakao-tech-campus/Team18_FE/assets/81379968/13b27097-bafc-41c5-98b0-f9b21bde53ae)

## Issue

- Close #3
