### PR TITLE
mock api 연결

### DIFF
--- a/src/apis/user.js
+++ b/src/apis/user.js
@@ -1,4 +1,5 @@
 import { instance } from "./instance";
+import { mockUsers, mockResponse } from "../components/account/mockUser";
 
 // api 요청
 export const register = (data) => {
@@ -15,10 +16,37 @@ export const register = (data) => {
   });
 };
 
-export const login = (data) => {
-  const { email, password } = data;
-  return instance.post("/login", {
-    email,
-    password,
-  });
+// export const login = (data) => {
+//   const { email, password } = data;
+//   return instance.post("/login", {
+//     email,
+//     password,
+//   });
+// };
+
+export const login = async (data) => {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  // 사용자의 email이 mock data의 key 값과 일치하면
+  const user = mockUsers[data.email];
+  // 패스워드 일치 확인
+  if (user && user.password === data.password) {
+    const responseUser = {
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      role: user.role,
+      country: user.country,
+      interest: user.interest,
+    };
+    return mockResponse({
+      message: "Login successful",
+      user: responseUser,
+    });
+  } else {
+    return mockResponse({
+      message: "Invalid email or password",
+      success: false,
+    });
+  }
 };

--- a/src/components/account/mockUser.js
+++ b/src/components/account/mockUser.js
@@ -1,0 +1,22 @@
+export const mockUsers = {
+  "user@example.com": {
+    email: "user@example.com",
+    password: "password123!",
+    firstName: "John",
+    lastName: "Doe",
+    role: "user",
+    country: "US",
+    interest: null,
+  },
+};
+
+export const mockResponse = (data) => ({
+  data: data,
+  status: 200,
+  statusText: "OK",
+  headers: {
+    authorization: "Bearer {JWT Token}",
+  },
+  config: {},
+  request: {},
+});

--- a/src/components/account/organisms/LoginForm.jsx
+++ b/src/components/account/organisms/LoginForm.jsx
@@ -4,8 +4,11 @@ import InputBox from "../atoms/InputBox";
 import Button from "../../common/Button";
 import { useAtom } from "jotai";
 import { userAtom } from "../../../store";
+import { login } from "../../../apis/user";
+import { useNavigate } from "react-router-dom";
 
 const LoginForm = ({ inputProps }) => {
+  const navigate = useNavigate();
   const methods = useForm();
   const { watch, control, handleSubmit } = methods;
   const email = watch("email");
@@ -13,11 +16,23 @@ const LoginForm = ({ inputProps }) => {
 
   const [user, setUser] = useAtom(userAtom);
 
-  const onSubmit = (data) => {
-    console.log("Email:", email);
-    console.log("Password:", password);
+  const onSubmit = async () => {
+    try {
+      const response = await login({
+        email: email,
+        password: password,
+      });
 
-    setUser({ email, password });
+      if (response.data.message === "Login successful") {
+        setUser(response.data.user);
+        console.log(response.data.message); // 로그인 성공 실패 여부 확인
+        localStorage.setItem("token", response.headers.authorization);
+        localStorage.setItem("user", JSON.stringify(response.data.user));
+        navigate("/", { replace: true });
+      }
+    } catch (error) {
+      console.error("Error during login:", error);
+    }
   };
 
   return (

--- a/src/layouts/GNB.jsx
+++ b/src/layouts/GNB.jsx
@@ -19,6 +19,7 @@ export default function GNB() {
 
   const handleLogOutClick = () => {
     window.localStorage.removeItem("token");
+    window.localStorage.removeItem("user");
     setAuth(!!window.localStorage.getItem("token"));
   };
 


### PR DESCRIPTION
## Summary

로그인 시 mock 객체로 user 정보 가져옴 

## Details
<img width="955" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team18_FE/assets/103165845/d7e8c1e7-bbc3-47d5-b319-999f9af978ca">


- mockUser 객체를 만들고, 객체의 키값과 사용자가 입력한 email값이 동일하고 해당 객체의 password 값이 동일한 경우 응답 데이터에 저장되도록 함

- 백앤드 api 개발 전, 임시로 사용자 정보를 사용하기 위해 구현함

-  `setUser(response.data.user);` 로 사용자 정보를 전역 상태로 저장 

```
email : user@example.com
password : password123!
```
