### PR TITLE
멘토링 대시보드 구현

### DIFF
--- a/src/apis/mentoring/connetion.js
+++ b/src/apis/mentoring/connetion.js
@@ -1,5 +1,14 @@
 import { instance } from "../instance";
-import { isMock, mockResponse } from "./mock";
+import { isMock, mockResponse, postCountsData } from "./mock";
+
+export async function getPostCountsReq() {
+  if (isMock) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    return mockResponse(postCountsData);
+  } else {
+    return await instance.get("contacts/postCounts");
+  }
+}
 
 export async function getConnectiontsReq() {
   if (isMock) {

--- a/src/apis/mentoring/connetion.js
+++ b/src/apis/mentoring/connetion.js
@@ -1,5 +1,11 @@
 import { instance } from "../instance";
-import { isMock, mockResponse, postCountsData } from "./mock";
+import {
+  isMock,
+  mockResponse,
+  postCountsData,
+  ContactsData,
+  DonesData,
+} from "./mock";
 
 export async function getPostCountsReq() {
   if (isMock) {
@@ -13,7 +19,7 @@ export async function getPostCountsReq() {
 export async function getContactConnectionsReq() {
   if (isMock) {
     await new Promise((resolve) => setTimeout(resolve, 500));
-    return mockResponse(null);
+    return mockResponse(ContactsData);
   } else {
     return await instance.get("/contacts");
   }
@@ -22,7 +28,7 @@ export async function getContactConnectionsReq() {
 export async function getDoneConnectionsReq() {
   if (isMock) {
     await new Promise((resolve) => setTimeout(resolve, 500));
-    return mockResponse(null);
+    return mockResponse(DonesData);
   } else {
     return await instance.get("/contacts/done");
   }

--- a/src/apis/mentoring/connetion.js
+++ b/src/apis/mentoring/connetion.js
@@ -10,20 +10,35 @@ export async function getPostCountsReq() {
   }
 }
 
-export async function getConnectiontsReq() {
+export async function getContactConnectionsReq() {
   if (isMock) {
-    1;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    return mockResponse(null);
   } else {
     return await instance.get("/contacts");
   }
 }
 
-export async function addConnectionReq(pid) {
+export async function getDoneConnectionsReq() {
   if (isMock) {
     await new Promise((resolve) => setTimeout(resolve, 500));
     return mockResponse(null);
   } else {
-    return await instance.post(`/contacts/${pid}`);
+    return await instance.get("/contacts/done");
+  }
+}
+
+export async function addConnectionReq(data) {
+  if (isMock) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    return mockResponse(null);
+  } else {
+    const { menteeId, mentorId, mentorPostId } = data;
+    return await instance.post("/contacts", {
+      menteeId,
+      mentorId,
+      mentorPostId,
+    });
   }
 }
 
@@ -32,7 +47,10 @@ export async function deleteConnectionReq(uids) {
     await new Promise((resolve) => setTimeout(resolve, 500));
     return mockResponse(null);
   } else {
-    return await instance.delete(`/contacts/`);
+    const queryParam = uids
+      .reduce((acc, uid) => `${acc}${uid},`, "?connectionId=")
+      .slice(0, -1);
+    return await instance.delete(`/contacts${queryParam}`);
   }
 }
 
@@ -41,7 +59,7 @@ export async function acceptConnectionReq(uids) {
     await new Promise((resolve) => setTimeout(resolve, 500));
     return mockResponse(null);
   } else {
-    return await instance.patch(`/contacts/accept`);
+    return await instance.post(`/contacts/accept`);
   }
 }
 

--- a/src/apis/mentoring/mock.js
+++ b/src/apis/mentoring/mock.js
@@ -96,4 +96,6 @@ export const postData = {
   ],
 };
 
+export const postCountsData = { contactCount: 3, doneCount: 2 };
+
 export const mutateRes = { postId: 1 };

--- a/src/apis/mentoring/mock.js
+++ b/src/apis/mentoring/mock.js
@@ -96,6 +96,113 @@ export const postData = {
   ],
 };
 
-export const postCountsData = { contactCount: 3, doneCount: 2 };
+export const postCountsData = { contactCount: 3, doneCount: 3 };
+
+export const ContactsData = {
+  postId: 1,
+  title: "글 제목",
+  mentor: {
+    mentorId: 1,
+    profileImage: IMAGE_URL,
+    name: "John Doe",
+    country: "US",
+    role: "MENTOR",
+    favorites: ["IDOL", "Game"],
+    birthDate: "2002-10-30",
+  },
+  mentees: [
+    {
+      contactId: 1,
+      connectionState: "await",
+      mentee: {
+        menteeId: 2,
+        name: "Jane",
+        profileImage: IMAGE_URL,
+        country: "DK",
+        favorites: ["Game", "Sports"],
+        role: "MENTEE",
+        birthDate: "1999-07-16",
+      },
+    },
+    {
+      contactId: 2,
+      connectionState: "accept",
+      mentee: {
+        menteeId: 3,
+        name: "Miho",
+        profileImage: IMAGE_URL,
+        country: "JP",
+        favorites: ["Game", "K-POP"],
+        role: "MENTEE",
+        birthDate: "2007-03-25",
+      },
+    },
+    {
+      contactId: 3,
+      connectionState: "refuse",
+      mentee: {
+        menteeId: 4,
+        name: "Michael",
+        profileImage: IMAGE_URL,
+        country: "US",
+        favorites: ["Sports", "Movie"],
+        role: "MENTEE",
+        birthDate: "1985-11-15",
+      },
+    },
+  ],
+};
+
+export const DonesData = [1, 2, 3].map(() => ({
+  postId: 1,
+  title: "글 제목",
+  mentor: {
+    mentorId: 1,
+    profileImage: IMAGE_URL,
+    name: "John Doe",
+    country: "US",
+    role: "MENTOR",
+    favorites: ["IDOL", "Game"],
+    birthDate: "2002-10-30",
+  },
+  mentees: [
+    {
+      doneId: 1,
+      mentee: {
+        menteeId: 2,
+        name: "Jane",
+        profileImage: IMAGE_URL,
+        country: "DK",
+        favorites: ["Game", "Sports"],
+        role: "MENTEE",
+        birthDate: "1999-07-16",
+      },
+    },
+    {
+      doneId: 2,
+      mentee: {
+        menteeId: 3,
+        name: "Miho",
+        profileImage: IMAGE_URL,
+        country: "JP",
+        favorites: ["Game", "K-POP"],
+        role: "MENTEE",
+        birthDate: "2007-03-25",
+      },
+    },
+    {
+      doneId: 3,
+      mentee: {
+        menteeId: 4,
+        name: "Michael",
+        profileImage: IMAGE_URL,
+        country: "US",
+        favorites: ["Sports", "Movie"],
+        role: "MENTEE",
+        birthDate: "1985-11-15",
+      },
+    },
+  ],
+}));
 
 export const mutateRes = { postId: 1 };

--- a/src/apis/mentoring/mock.js
+++ b/src/apis/mentoring/mock.js
@@ -98,62 +98,65 @@ export const postData = {
 
 export const postCountsData = { contactCount: 3, doneCount: 3 };
 
-export const ContactsData = {
+export const ContactsData = [1, 2, 3].map((val) => ({
   postId: 1,
   title: "글 제목",
-  mentor: {
+  writerDTO: {
     mentorId: 1,
     profileImage: IMAGE_URL,
     name: "John Doe",
     country: "US",
+    birthDate: "2002-10-30",
     role: "MENTOR",
     favorites: ["IDOL", "Game"],
-    birthDate: "2002-10-30",
   },
+  // mentee용
+  connectionId: val,
+  // mentor용
   mentees: [
     {
-      contactId: 1,
-      connectionState: "await",
+      connectionId: 1,
+      state: "AWAIT",
       mentee: {
         menteeId: 2,
-        name: "Jane",
         profileImage: IMAGE_URL,
+        name: "Jane",
         country: "DK",
-        favorites: ["Game", "Sports"],
-        role: "MENTEE",
         birthDate: "1999-07-16",
+        role: "MENTEE",
+        favorites: ["Game", "Sports"],
       },
     },
     {
-      contactId: 2,
-      connectionState: "accept",
+      connectionId: 2,
+      state: "ACCEPT",
       mentee: {
         menteeId: 3,
-        name: "Miho",
         profileImage: IMAGE_URL,
+        name: "Miho",
         country: "JP",
-        favorites: ["Game", "K-POP"],
-        role: "MENTEE",
         birthDate: "2007-03-25",
+        role: "MENTEE",
+        favorites: ["Game", "K-POP"],
       },
     },
     {
-      contactId: 3,
-      connectionState: "refuse",
+      connectionId: 3,
+      state: "REFUSE",
       mentee: {
         menteeId: 4,
-        name: "Michael",
         profileImage: IMAGE_URL,
+        name: "Michael",
         country: "US",
-        favorites: ["Sports", "Movie"],
-        role: "MENTEE",
         birthDate: "1985-11-15",
+        role: "MENTEE",
+        favorites: ["Sports", "Movie"],
       },
     },
   ],
-};
+}));
 
-export const DonesData = [1, 2, 3].map(() => ({
+export const DonesData = [1, 2, 3].map((val) => ({
   postId: 1,
   title: "글 제목",
   mentor: {
@@ -161,45 +164,45 @@ export const DonesData = [1, 2, 3].map(() => ({
     profileImage: IMAGE_URL,
     name: "John Doe",
     country: "US",
+    birthDate: "2002-10-30",
     role: "MENTOR",
     favorites: ["IDOL", "Game"],
-    birthDate: "2002-10-30",
   },
   mentees: [
     {
       doneId: 1,
       mentee: {
         menteeId: 2,
-        name: "Jane",
         profileImage: IMAGE_URL,
-        country: "DK",
-        favorites: ["Game", "Sports"],
-        role: "MENTEE",
+        name: "Jane",
         birthDate: "1999-07-16",
+        country: "DK",
+        role: "MENTEE",
+        favorites: ["Game", "Sports"],
       },
     },
     {
       doneId: 2,
       mentee: {
         menteeId: 3,
-        name: "Miho",
         profileImage: IMAGE_URL,
+        name: "Miho",
         country: "JP",
-        favorites: ["Game", "K-POP"],
-        role: "MENTEE",
         birthDate: "2007-03-25",
+        role: "MENTEE",
+        favorites: ["Game", "K-POP"],
       },
     },
     {
       doneId: 3,
       mentee: {
         menteeId: 4,
-        name: "Michael",
         profileImage: IMAGE_URL,
+        name: "Michael",
         country: "US",
-        favorites: ["Sports", "Movie"],
-        role: "MENTEE",
         birthDate: "1985-11-15",
+        role: "MENTEE",
+        favorites: ["Sports", "Movie"],
       },
     },
   ],

--- a/src/apis/mentoring/post.js
+++ b/src/apis/mentoring/post.js
@@ -24,7 +24,7 @@ export async function getPostsReq(category, search, page) {
     return page < 2 ? mockResponse(postsData) : mockResponse([]);
   } else {
     return await instance.get(
-      `/mentorings/post?category=${category}&search=${search}&page=${page}`
+      `/mentorings?category=${category}&search=${search}&page=${page}`
     );
   }
 }
@@ -34,7 +34,7 @@ export async function getPostReq(postId) {
     await new Promise((resolve) => setTimeout(resolve, 500));
     return mockResponse(postData);
   } else {
-    return await instance.get(`/mentorings/post/${postId}`);
+    return await instance.get(`/mentorings/${postId}`);
   }
 }
 
@@ -44,7 +44,7 @@ export async function addPostReq(data) {
     return mockResponse(mutateRes);
   } else {
     const { title, content } = data;
-    return await instance.post("/mentorings/post", {
+    return await instance.post("/mentorings", {
       title,
       content,
     });
@@ -57,7 +57,7 @@ export async function editPostReq(postId, data) {
     return mockResponse(mutateRes);
   } else {
     const { title, content } = data;
-    return await instance.put(`/mentorings/post/${postId}`, {
+    return await instance.put(`/mentorings/${postId}`, {
       title,
       content,
     });
@@ -69,7 +69,7 @@ export async function deletePostReq(postId) {
     await new Promise((resolve) => setTimeout(resolve, 500));
     return mockResponse(null);
   } else {
-    return await instance.delete(`/mentorings/post/${postId}`);
+    return await instance.delete(`/mentorings/${postId}`);
   }
 }
 
@@ -78,6 +78,6 @@ export async function donePostReq(postId) {
     await new Promise((resolve) => setTimeout(resolve, 500));
     return mockResponse(null);
   } else {
-    return await instance.patch(`/mentorings/post/${postId}/done`);
+    return await instance.patch(`/mentorings/${postId}/done`);
   }
 }

--- a/src/components/mentoring/dashboard/ContactTabMenteeSide.jsx
+++ b/src/components/mentoring/dashboard/ContactTabMenteeSide.jsx
@@ -1,3 +1,172 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+
+import {
+  getContactConnectionsReq,
+  deleteConnectionReq,
+} from "../../../apis/mentoring/connetion";
+import { convertDateToAge } from "../../../utils/age";
+
+import FlagTag from "../../common/FlagTag";
+import Tag from "../../common/Tag";
+import Button from "../../common/Button";
+import ProfileModal from "./ProfileModal";
+
 export default function ContactTabMenteeSide() {
-  return <span>ContactTabMenteeSide</span>;
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    queryKey: ["contacts"],
+    queryFn: getContactConnectionsReq,
+  });
+
+  const [checks, setChecks] = useState(
+    data.data.data.reduce((acc, post) => {
+      return { ...acc, [post.connectionId]: false };
+    }, {})
+  );
+
+  const { mutate: deleteMutate } = useMutation({
+    mutationFn: deleteConnectionReq,
+  });
+
+  const handleCheckBoxChange = (e) => {
+    const name = e.target.name;
+    if (name === "all") {
+      setChecks(
+        Object.keys(checks).reduce(
+          (acc, key) => ({ ...acc, [key]: e.target.checked }),
+          {}
+        )
+      );
+    } else {
+      setChecks((prev) => ({ ...prev, [name]: !prev[name] }));
+    }
+  };
+
+  const handleCancelClick = () => {
+    if (window.confirm("Are you sure you want to cancel?")) {
+      deleteMutate(
+        Object.keys(checks).reduce((acc, key) => {
+          if (checks[key] === true) return [...acc, key];
+          else return [...acc];
+        }, []),
+        {
+          onSuccess: () => {
+            toast("Successfully canceled.");
+            queryClient.invalidateQueries({
+              queryKey: ["contacts"],
+            });
+            setChecks(
+              data.data.data.reduce((acc, post) => {
+                return { ...acc, [post.connectionId]: false };
+              }, {})
+            );
+          },
+        }
+      );
+    } else toast("No mentors have been selected.");
+  };
+
+  const handlePostClick = (e) => {
+    const name = e.currentTarget.name;
+    navigate(`/mentoring/post/${name}`);
+  };
+
+  const handleProfileClick = (e) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <>
+      <table className="text-center">
+        {/* 테이블 헤더 */}
+        <thead>
+          <tr className="bg-gray-100 border">
+            <th>
+              <input
+                type="checkbox"
+                name="all"
+                className="accent-green-600"
+                checked={Object.values(checks).every((val) => val === true)}
+                onChange={handleCheckBoxChange}
+              />
+            </th>
+            <th className="p-2 text-left font-medium">Name</th>
+            {["Country", "Position", "Favorite", "Age", ""].map((val, idx) => (
+              <th key={`thead-${idx}`} className="font-medium">
+                {val}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        {/* 테이블 바디(멘토행) */}
+        <tbody>
+          {data.data.data.map((post, postIdx) => (
+            <tr
+              key={`mentor-${postIdx}`}
+              id={post.postId}
+              className="bg-white border"
+            >
+              <td>
+                <input
+                  type="checkbox"
+                  name={post.connectionId}
+                  className="accent-green-600"
+                  checked={checks[post.connectionId]}
+                  onChange={handleCheckBoxChange}
+                />
+              </td>
+              <td className="p-2 text-left space-x-2 flex items-center">
+                <img
+                  className="inline w-8 rounded-full"
+                  src={post.writerDTO.profileImage}
+                  alt={`${post.writerDTO.mentorId} 프로필 이미지`}
+                ></img>
+                <div className="inline-flex flex-col">
+                  <span className="font-medium">{post.writerDTO.name}</span>
+                  <span className="text-xs text-gray-500">{post.title}</span>
+                </div>
+              </td>
+              <td>
+                <FlagTag>{post.writerDTO.country}</FlagTag>
+              </td>
+              <td>
+                <Tag>{post.writerDTO.role}</Tag>
+              </td>
+              <td className="space-x-2">
+                {post.writerDTO.favorites.map((favorite, index) => (
+                  <Tag key={`mentortag-${index}`}>{favorite}</Tag>
+                ))}
+              </td>
+              <td>
+                <Tag>{convertDateToAge(post.writerDTO.birthDate) + ""}</Tag>
+              </td>
+              <td className="p-2 text-right space-x-2">
+                <button name={post.postId} onClick={handlePostClick}>
+                  <span className="material-symbols-outlined text-gray-400">
+                    file_open
+                  </span>
+                </button>
+                <button onClick={handleProfileClick}>
+                  <span className="material-symbols-outlined text-gray-400">
+                    account_circle
+                  </span>
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="mt-4 text-right">
+        <Button color="white" size="sm" onClick={handleCancelClick}>
+          Cancel
+        </Button>
+      </div>
+      <ProfileModal />
+    </>
+  );
 }

--- a/src/components/mentoring/dashboard/ContactTabMenteeSide.jsx
+++ b/src/components/mentoring/dashboard/ContactTabMenteeSide.jsx
@@ -1,0 +1,3 @@
+export default function ContactTabMenteeSide() {
+  return <span>ContactTabMenteeSide</span>;
+}

--- a/src/components/mentoring/dashboard/ContactTabMenteeSide.jsx
+++ b/src/components/mentoring/dashboard/ContactTabMenteeSide.jsx
@@ -12,11 +12,18 @@ import { convertDateToAge } from "../../../utils/age";
 import FlagTag from "../../common/FlagTag";
 import Tag from "../../common/Tag";
 import Button from "../../common/Button";
+import Fallback from "../../common/Fallback";
+import Loader from "../../common/Loader";
+import Error from "../../common/Error";
 import ProfileModal from "./ProfileModal";
 
 export default function ContactTabMenteeSide() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+
+  const [isModal, setIsModal] = useState(false);
+
+  const [modalUid, setModalUid] = useState(null);
 
   const { data } = useQuery({
     queryKey: ["contacts"],
@@ -78,6 +85,8 @@ export default function ContactTabMenteeSide() {
 
   const handleProfileClick = (e) => {
     e.stopPropagation();
+    setModalUid(e.currentTarget.name);
+    setIsModal(true);
   };
 
   return (
@@ -151,7 +160,10 @@ export default function ContactTabMenteeSide() {
                     file_open
                   </span>
                 </button>
-                <button onClick={handleProfileClick}>
+                <button
+                  name={post.writerDTO.mentorId}
+                  onClick={handleProfileClick}
+                >
                   <span className="material-symbols-outlined text-gray-400">
                     account_circle
                   </span>
@@ -166,7 +178,13 @@ export default function ContactTabMenteeSide() {
           Cancel
         </Button>
       </div>
-      <ProfileModal />
+      <Fallback Loader={Loader} Error={Error} errorMessage="ERROR">
+        <ProfileModal
+          isModal={isModal}
+          setIsModal={setIsModal}
+          uid={modalUid}
+        />
+      </Fallback>
     </>
   );
 }

--- a/src/components/mentoring/dashboard/ContactTabMentorSide.jsx
+++ b/src/components/mentoring/dashboard/ContactTabMentorSide.jsx
@@ -1,0 +1,3 @@
+export default function ContactTabMentorSide() {
+  return <span>ContactTabMentorSide</span>;
+}

--- a/src/components/mentoring/dashboard/ContactTabMentorSide.jsx
+++ b/src/components/mentoring/dashboard/ContactTabMentorSide.jsx
@@ -1,3 +1,271 @@
+import { useState, Fragment } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
+
+import {
+  acceptConnectionReq,
+  getContactConnectionsReq,
+  refuseConnectionReq,
+} from "../../../apis/mentoring/connetion";
+import { convertDateToAge } from "../../../utils/age";
+
+import FlagTag from "../../common/FlagTag";
+import Tag from "../../common/Tag";
+import ProfileModal from "./ProfileModal";
+import { connectionState } from "../../../constants/mentoring";
+import Button from "../../common/Button";
+import toast from "react-hot-toast";
+
 export default function ContactTabMentorSide() {
-  return <span>ContactTabMentorSide</span>;
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    queryKey: ["contacts"],
+    queryFn: getContactConnectionsReq,
+  });
+
+  const [postVisible, setPostVisible] = useState(
+    data.data.data.reduce((acc, post) => ({ ...acc, [post.postId]: false }), {})
+  );
+
+  const [checks, setChecks] = useState(
+    data.data.data
+      .flatMap((post) => post.mentees)
+      .reduce((acc, connection) => {
+        if (connection.state === connectionState.AWAIT)
+          return { ...acc, [connection.connectionId]: false };
+        else return acc;
+      }, {})
+  );
+
+  const { mutate: acceptMutate } = useMutation({
+    mutationFn: acceptConnectionReq,
+  });
+
+  const { mutate: refuseMutate } = useMutation({
+    mutationFn: refuseConnectionReq,
+  });
+
+  const handleCheckBoxChange = (e) => {
+    const name = e.target.name;
+    if (name === "all") {
+      setChecks(
+        Object.keys(checks).reduce(
+          (acc, key) => ({ ...acc, [key]: e.target.checked }),
+          {}
+        )
+      );
+    } else {
+      setChecks((prev) => ({ ...prev, [name]: !prev[name] }));
+    }
+  };
+
+  const handleMentorClick = (e) => {
+    const id = e.currentTarget.id;
+    setPostVisible((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const handleAcceptClick = () => {
+    if (Object.values(checks).some((val) => val)) {
+      if (window.confirm("Are you sure you want to accept mentees?"))
+        acceptMutate(
+          Object.keys(checks).reduce((acc, key) => {
+            if (checks[key] === true) return [...acc, key];
+            else return [...acc];
+          }, []),
+          {
+            onSuccess: () => {
+              toast("Successfully accepted.");
+              queryClient.invalidateQueries({
+                queryKey: ["post", data.postId],
+              });
+              setChecks(
+                data.data.data
+                  .flatMap((post) => post.mentees)
+                  .reduce((acc, connection) => {
+                    if (connection.state === connectionState.AWAIT)
+                      return { ...acc, [connection.connectionId]: false };
+                    else return acc;
+                  }, {})
+              );
+            },
+          }
+        );
+    } else toast("No mentees have been selected.");
+  };
+
+  const handleRefuseClick = () => {
+    if (Object.values(checks).some((val) => val)) {
+      if (window.confirm("Are you sure you want to refuse mentees?"))
+        refuseMutate(
+          Object.keys(checks).reduce((acc, key) => {
+            if (checks[key] === true) return [...acc, key];
+            else return [...acc];
+          }, []),
+          {
+            onSuccess: () => {
+              toast("Successfully refused.");
+              queryClient.invalidateQueries({
+                queryKey: ["post", data.postId],
+              });
+              setChecks(
+                data.data.data
+                  .flatMap((post) => post.mentees)
+                  .reduce((acc, connection) => {
+                    if (connection.state === connectionState.AWAIT)
+                      return { ...acc, [connection.connectionId]: false };
+                    else return acc;
+                  }, {})
+              );
+            },
+          }
+        );
+    } else toast("No mentees have been selected.");
+  };
+
+  const handlePostClick = (e) => {
+    const name = e.currentTarget.name;
+    navigate(`/mentoring/post/${name}`);
+  };
+
+  const handleProfileClick = (e) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <>
+      <table className="text-center">
+        {/* 테이블 헤더 */}
+        <thead>
+          <tr className="bg-gray-100 border">
+            <th>
+              <input
+                type="checkbox"
+                name="all"
+                className="accent-green-600"
+                checked={Object.values(checks).every((val) => val === true)}
+                onChange={handleCheckBoxChange}
+              />
+            </th>
+            <th className="p-2 text-left font-medium">Name</th>
+            {["Country", "Position", "Favorite", "Age", "State", ""].map(
+              (val, idx) => (
+                <th key={`thead-${idx}`} className="font-medium">
+                  {val}
+                </th>
+              )
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {data.data.data.map((post, postIdx) => (
+            <Fragment key={`mentor-${postIdx}`}>
+              {/* 테이블 멘토행 */}
+              <tr
+                id={post.postId}
+                className="bg-white border"
+                onClick={handleMentorClick}
+              >
+                <td></td>
+                <td className="p-2 text-left space-x-2">
+                  <img
+                    className="inline w-8 rounded-full"
+                    src={post.writerDTO.profileImage}
+                    alt={`${post.writerDTO.mentorId} 프로필 이미지`}
+                  ></img>
+                  <span className="font-medium">{post.title}</span>
+                </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td className="p-2 text-right space-x-2">
+                  <button name={post.postId} onClick={handlePostClick}>
+                    <span className="material-symbols-outlined text-gray-400">
+                      file_open
+                    </span>
+                  </button>
+                  <button onClick={handleProfileClick}>
+                    <span className="material-symbols-outlined text-gray-400">
+                      account_circle
+                    </span>
+                  </button>
+                </td>
+              </tr>
+              {/* 테이블 멘티행 */}
+              {postVisible[post.postId] &&
+                post.mentees.map((connection, connectIdx) => (
+                  <tr
+                    key={`mentee-${connectIdx}`}
+                    className={`bg-white border${
+                      post.mentees.length === connectIdx + 1
+                        ? " border-b-4"
+                        : ""
+                    }`}
+                  >
+                    <td>
+                      <input
+                        type="checkbox"
+                        name={connection.connectionId}
+                        className="accent-green-600"
+                        checked={checks[connection.connectionId]}
+                        onChange={handleCheckBoxChange}
+                        disabled={connection.state !== connectionState.AWAIT}
+                      />
+                    </td>
+                    <td className="p-2 text-left space-x-2">
+                      <img
+                        className="inline w-8 rounded-full"
+                        src={connection.mentee.profileImage}
+                        alt={`${connection.mentee.menteeId} 프로필 이미지`}
+                      ></img>
+                      <span className="font-medium">
+                        {connection.mentee.name}
+                      </span>
+                    </td>
+                    <td>
+                      <FlagTag>{connection.mentee.country}</FlagTag>
+                    </td>
+                    <td>
+                      <Tag>{connection.mentee.role}</Tag>
+                    </td>
+                    <td className="space-x-2">
+                      {connection.mentee.favorites.map((favorite, index) => (
+                        <Tag key={`menteetag-${index}`}>{favorite}</Tag>
+                      ))}
+                    </td>
+                    <td>
+                      <Tag>
+                        {convertDateToAge(connection.mentee.birthDate) + ""}
+                      </Tag>
+                    </td>
+                    <td>
+                      <Tag>{connection.state}</Tag>
+                    </td>
+                    <td className="p-2 text-right">
+                      <button onClick={handleProfileClick}>
+                        <span className="material-symbols-outlined text-gray-400">
+                          account_circle
+                        </span>
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+            </Fragment>
+          ))}
+        </tbody>
+      </table>{" "}
+      <div className="mt-4 text-right space-x-2">
+        <Button color="white" size="sm" onClick={handleAcceptClick}>
+          Accept
+        </Button>
+        <Button color="white" size="sm" onClick={handleRefuseClick}>
+          Refuse
+        </Button>
+      </div>
+      <ProfileModal />
+    </>
+  );
 }

--- a/src/components/mentoring/dashboard/ContactTabMentorSide.jsx
+++ b/src/components/mentoring/dashboard/ContactTabMentorSide.jsx
@@ -1,6 +1,7 @@
 import { useState, Fragment } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
+import toast from "react-hot-toast";
 
 import {
   acceptConnectionReq,
@@ -8,17 +9,23 @@ import {
   refuseConnectionReq,
 } from "../../../apis/mentoring/connetion";
 import { convertDateToAge } from "../../../utils/age";
+import { connectionState } from "../../../constants/mentoring";
 
 import FlagTag from "../../common/FlagTag";
 import Tag from "../../common/Tag";
-import ProfileModal from "./ProfileModal";
-import { connectionState } from "../../../constants/mentoring";
 import Button from "../../common/Button";
-import toast from "react-hot-toast";
+import Fallback from "../../common/Fallback";
+import Loader from "../../common/Loader";
+import Error from "../../common/Error";
+import ProfileModal from "./ProfileModal";
 
 export default function ContactTabMentorSide() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+
+  const [isModal, setIsModal] = useState(false);
+
+  const [modalUid, setModalUid] = useState(null);
 
   const { data } = useQuery({
     queryKey: ["contacts"],
@@ -131,6 +138,8 @@ export default function ContactTabMentorSide() {
 
   const handleProfileClick = (e) => {
     e.stopPropagation();
+    setModalUid(e.currentTarget.name);
+    setIsModal(true);
   };
 
   return (
@@ -187,7 +196,10 @@ export default function ContactTabMentorSide() {
                       file_open
                     </span>
                   </button>
-                  <button onClick={handleProfileClick}>
+                  <button
+                    name={post.writerDTO.mentorId}
+                    onClick={handleProfileClick}
+                  >
                     <span className="material-symbols-outlined text-gray-400">
                       account_circle
                     </span>
@@ -245,7 +257,10 @@ export default function ContactTabMentorSide() {
                       <Tag>{connection.state}</Tag>
                     </td>
                     <td className="p-2 text-right">
-                      <button onClick={handleProfileClick}>
+                      <button
+                        name={connection.mentee.menteeId}
+                        onClick={handleProfileClick}
+                      >
                         <span className="material-symbols-outlined text-gray-400">
                           account_circle
                         </span>
@@ -265,7 +280,13 @@ export default function ContactTabMentorSide() {
           Refuse
         </Button>
       </div>
-      <ProfileModal />
+      <Fallback Loader={Loader} Error={Error} errorMessage="ERROR">
+        <ProfileModal
+          isModal={isModal}
+          setIsModal={setIsModal}
+          uid={modalUid}
+        />
+      </Fallback>
     </>
   );
 }

--- a/src/components/mentoring/dashboard/DashboardSection.jsx
+++ b/src/components/mentoring/dashboard/DashboardSection.jsx
@@ -26,7 +26,6 @@ export default function DashboardSection() {
     queryFn: () => getPostCountsReq(),
   });
 
-  const handleTabClick = () => {};
   return (
     <div className="flex justify-center">
       <div className="w-full max-w-[58rem] m-16 flex flex-col space-y-5">

--- a/src/components/mentoring/dashboard/DashboardSection.jsx
+++ b/src/components/mentoring/dashboard/DashboardSection.jsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { tabState, userRole } from "../../../constants/mentoring";
+import { getUser } from "../../../apis/mentoring/post";
+import { getPostCountsReq } from "../../../apis/mentoring/connetion";
+
+import TabBar from "./TabBar";
+import Fallback from "../../common/Fallback";
+import Loader from "../../common/Loader";
+import Error from "../../common/Error";
+import ContactTabMentorSide from "./ContactTabMentorSide";
+import ContactTabMenteeSide from "./ContactTabMenteeSide";
+import DoneTab from "./DoneTab";
+
+export default function DashboardSection() {
+  const [tab, setTab] = useState(tabState.CONTACT);
+
+  const { data: userData } = useQuery({
+    queryKey: ["user"],
+    queryFn: getUser,
+  });
+
+  const { data } = useQuery({
+    queryKey: ["postCounts"],
+    queryFn: () => getPostCountsReq(),
+  });
+
+  const handleTabClick = () => {};
+  return (
+    <div className="flex justify-center">
+      <div className="w-full max-w-[58rem] m-16 flex flex-col space-y-5">
+        <h1 className="text-4xl font-bold text-green-700">Dashboard</h1>
+        <TabBar currentTab={tab} setTab={setTab} postCounts={data.data.data} />
+        <Fallback
+          Loader={Loader}
+          Error={Error}
+          errorMessage="Failed to load dashboard tab"
+        >
+          {tab === tabState.CONTACT ? (
+            userData.data.data.role === userRole.MENTOR ? (
+              <ContactTabMentorSide />
+            ) : (
+              <ContactTabMenteeSide />
+            )
+          ) : (
+            <DoneTab />
+          )}
+        </Fallback>
+      </div>
+    </div>
+  );
+}

--- a/src/components/mentoring/dashboard/DoneTab.jsx
+++ b/src/components/mentoring/dashboard/DoneTab.jsx
@@ -58,13 +58,16 @@ export default function DoneTab() {
                 className="bg-white border"
                 onClick={handleMentorClick}
               >
-                <td className="p-2 text-left space-x-2">
+                <td className="p-2 text-left space-x-2 flex items-center">
                   <img
                     className="inline w-8 rounded-full"
                     src={post.mentor.profileImage}
                     alt={`${post.mentor.mentorId} 프로필 이미지`}
                   ></img>
-                  <span className="font-medium">{post.mentor.name}</span>
+                  <div className="inline-flex flex-col">
+                    <span className="font-medium">{post.mentor.name}</span>
+                    <span className="text-xs text-gray-500">{post.title}</span>
+                  </div>
                 </td>
                 <td>
                   <FlagTag>{post.mentor.country}</FlagTag>

--- a/src/components/mentoring/dashboard/DoneTab.jsx
+++ b/src/components/mentoring/dashboard/DoneTab.jsx
@@ -7,10 +7,17 @@ import { convertDateToAge } from "../../../utils/age";
 
 import FlagTag from "../../common/FlagTag";
 import Tag from "../../common/Tag";
+import Fallback from "../../common/Fallback";
+import Loader from "../../common/Loader";
+import Error from "../../common/Error";
 import ProfileModal from "./ProfileModal";
 
 export default function DoneTab() {
   const navigate = useNavigate();
+
+  const [isModal, setIsModal] = useState(false);
+
+  const [modalUid, setModalUid] = useState(null);
 
   const { data } = useQuery({
     queryKey: ["dones"],
@@ -33,6 +40,8 @@ export default function DoneTab() {
 
   const handleProfileClick = (e) => {
     e.stopPropagation();
+    setModalUid(e.currentTarget.name);
+    setIsModal(true);
   };
 
   return (
@@ -89,7 +98,10 @@ export default function DoneTab() {
                       file_open
                     </span>
                   </button>
-                  <button onClick={handleProfileClick}>
+                  <button
+                    name={post.mentor.mentorId}
+                    onClick={handleProfileClick}
+                  >
                     <span className="material-symbols-outlined text-gray-400">
                       account_circle
                     </span>
@@ -134,7 +146,10 @@ export default function DoneTab() {
                       </Tag>
                     </td>
                     <td className="p-2 text-right">
-                      <button onClick={handleProfileClick}>
+                      <button
+                        name={connection.mentee.menteeId}
+                        onClick={handleProfileClick}
+                      >
                         <span className="material-symbols-outlined text-gray-400">
                           account_circle
                         </span>
@@ -146,7 +161,13 @@ export default function DoneTab() {
           ))}
         </tbody>
       </table>
-      <ProfileModal />
+      <Fallback Loader={Loader} Error={Error} errorMessage="ERROR">
+        <ProfileModal
+          isModal={isModal}
+          setIsModal={setIsModal}
+          uid={modalUid}
+        />
+      </Fallback>
     </>
   );
 }

--- a/src/components/mentoring/dashboard/DoneTab.jsx
+++ b/src/components/mentoring/dashboard/DoneTab.jsx
@@ -1,0 +1,3 @@
+export default function DoneTab() {
+  return <span>DoneTab</span>;
+}

--- a/src/components/mentoring/dashboard/DoneTab.jsx
+++ b/src/components/mentoring/dashboard/DoneTab.jsx
@@ -1,3 +1,149 @@
+import { useState, Fragment } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+
+import { getDoneConnectionsReq } from "../../../apis/mentoring/connetion";
+import { convertDateToAge } from "../../../utils/age";
+
+import FlagTag from "../../common/FlagTag";
+import Tag from "../../common/Tag";
+import ProfileModal from "./ProfileModal";
+
 export default function DoneTab() {
-  return <span>DoneTab</span>;
+  const navigate = useNavigate();
+
+  const { data } = useQuery({
+    queryKey: ["dones"],
+    queryFn: getDoneConnectionsReq,
+  });
+
+  const [postVisible, setPostVisible] = useState(
+    data.data.data.reduce((acc, post) => ({ ...acc, [post.postId]: false }), {})
+  );
+
+  const handleMentorClick = (e) => {
+    const id = e.currentTarget.id;
+    setPostVisible((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const handlePostClick = (e) => {
+    const name = e.currentTarget.name;
+    navigate(`/mentoring/post/${name}`);
+  };
+
+  const handleProfileClick = (e) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <>
+      <table className="text-center">
+        {/* 테이블 헤더 */}
+        <thead>
+          <tr className="bg-gray-100 border">
+            <th className="p-2 text-left font-medium">Name</th>
+            {["Country", "Position", "Favorite", "Age", ""].map((val, idx) => (
+              <th key={`thead-${idx}`} className="font-medium">
+                {val}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.data.data.map((post, postIdx) => (
+            <Fragment key={`mentor-${postIdx}`}>
+              {/* 테이블 멘토행 */}
+              <tr
+                id={post.postId}
+                className="bg-white border"
+                onClick={handleMentorClick}
+              >
+                <td className="p-2 text-left space-x-2">
+                  <img
+                    className="inline w-8 rounded-full"
+                    src={post.mentor.profileImage}
+                    alt={`${post.mentor.mentorId} 프로필 이미지`}
+                  ></img>
+                  <span className="font-medium">{post.mentor.name}</span>
+                </td>
+                <td>
+                  <FlagTag>{post.mentor.country}</FlagTag>
+                </td>
+                <td>
+                  <Tag>{post.mentor.role}</Tag>
+                </td>
+                <td className="space-x-2">
+                  {post.mentor.favorites.map((favorite, index) => (
+                    <Tag key={`mentortag-${index}`}>{favorite}</Tag>
+                  ))}
+                </td>
+                <td>
+                  <Tag>{convertDateToAge(post.mentor.birthDate) + ""}</Tag>
+                </td>
+                <td className="p-2 text-right space-x-2">
+                  <button name={post.postId} onClick={handlePostClick}>
+                    <span className="material-symbols-outlined text-gray-400">
+                      file_open
+                    </span>
+                  </button>
+                  <button onClick={handleProfileClick}>
+                    <span className="material-symbols-outlined text-gray-400">
+                      account_circle
+                    </span>
+                  </button>
+                </td>
+              </tr>
+              {/* 테이블 멘티행 */}
+              {postVisible[post.postId] &&
+                post.mentees.map((connection, connectIdx) => (
+                  <tr
+                    key={`mentee-${connectIdx}`}
+                    className={`bg-white border${
+                      post.mentees.length === connectIdx + 1
+                        ? " border-b-4"
+                        : ""
+                    }`}
+                  >
+                    <td className="p-2 text-left space-x-2">
+                      <img
+                        className="inline w-8 rounded-full"
+                        src={connection.mentee.profileImage}
+                        alt={`${connection.mentee.menteeId} 프로필 이미지`}
+                      ></img>
+                      <span className="font-medium">
+                        {connection.mentee.name}
+                      </span>
+                    </td>
+                    <td>
+                      <FlagTag>{connection.mentee.country}</FlagTag>
+                    </td>
+                    <td>
+                      <Tag>{connection.mentee.role}</Tag>
+                    </td>
+                    <td className="space-x-2">
+                      {connection.mentee.favorites.map((favorite, index) => (
+                        <Tag key={`menteetag-${index}`}>{favorite}</Tag>
+                      ))}
+                    </td>
+                    <td>
+                      <Tag>
+                        {convertDateToAge(connection.mentee.birthDate) + ""}
+                      </Tag>
+                    </td>
+                    <td className="p-2 text-right">
+                      <button onClick={handleProfileClick}>
+                        <span className="material-symbols-outlined text-gray-400">
+                          account_circle
+                        </span>
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+            </Fragment>
+          ))}
+        </tbody>
+      </table>
+      <ProfileModal />
+    </>
+  );
 }

--- a/src/components/mentoring/dashboard/ProfileModal.jsx
+++ b/src/components/mentoring/dashboard/ProfileModal.jsx
@@ -1,9 +1,44 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import Modal from "react-modal";
 
-export default function profileModal() {
+import { getProfileById } from "../../../apis/mypage";
+
+import Profile from "../../account/molecules/Profile";
+
+const customStyles = {
+  content: {
+    top: "50%",
+    left: "50%",
+    right: "auto",
+    bottom: "auto",
+    marginRight: "-50%",
+    transform: "translate(-50%, -50%)",
+  },
+};
+
+export default function ProfileModal({ isModal, setIsModal, uid }) {
+  // const { data } = useQuery(
+  //   ["getProfileById", uid],
+  //   () => getProfileById(uid),
+  //   { enabled: !!uid, suspense: true }
+  // );
+
+  const closeModal = () => {
+    setIsModal(false);
+  };
+
   return (
-    <Modal>
-      <span>프로필 모달</span>
+    <Modal
+      isOpen={isModal}
+      onRequestClose={closeModal}
+      style={customStyles}
+      contentLabel="Example Modal"
+    >
+      <button onClick={closeModal}>close</button>
+      {/* <Profile data={data} /> */}
+      <h1>프로필 모달</h1>
+      <h2>{uid}</h2>
     </Modal>
   );
 }

--- a/src/components/mentoring/dashboard/ProfileModal.jsx
+++ b/src/components/mentoring/dashboard/ProfileModal.jsx
@@ -1,0 +1,9 @@
+import Modal from "react-modal";
+
+export default function profileModal() {
+  return (
+    <Modal>
+      <span>프로필 모달</span>
+    </Modal>
+  );
+}

--- a/src/components/mentoring/dashboard/TabBar.jsx
+++ b/src/components/mentoring/dashboard/TabBar.jsx
@@ -1,0 +1,30 @@
+import { tabState } from "../../../constants/mentoring";
+
+export default function TabBar({ currentTab, setTab, postCounts }) {
+  const handleTabClick = (tab) => {
+    setTab(tab);
+  };
+
+  return (
+    <div className="border-b-2 space-x-5">
+      {Object.values(tabState).map((tab) => (
+        <button
+          key={`tab-${tab}`}
+          className={`${
+            tab === currentTab
+              ? "text-orange border-orange border-b-2 "
+              : "text-green-700 "
+          }px-1 py-2 inline-flex justify-center items-center space-x-1`}
+          onClick={() => {
+            handleTabClick(tab);
+          }}
+        >
+          <span className={tab === currentTab && "font-semibold"}>{tab}</span>
+          <span className="px-[7px] rounded-full bg-pink-300 text-sm text-[#ffff]">
+            {postCounts[`${tab.toLowerCase()}Count`]}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/mentoring/dashboard/TabBar.jsx
+++ b/src/components/mentoring/dashboard/TabBar.jsx
@@ -6,7 +6,7 @@ export default function TabBar({ currentTab, setTab, postCounts }) {
   };
 
   return (
-    <div className="border-b-2 space-x-5">
+    <div className="border-b-2 space-x-3">
       {Object.values(tabState).map((tab) => (
         <button
           key={`tab-${tab}`}
@@ -14,12 +14,12 @@ export default function TabBar({ currentTab, setTab, postCounts }) {
             tab === currentTab
               ? "text-orange border-orange border-b-2 "
               : "text-green-700 "
-          }px-1 py-2 inline-flex justify-center items-center space-x-1`}
+          }px-2 py-2 inline-flex justify-center items-center space-x-1`}
           onClick={() => {
             handleTabClick(tab);
           }}
         >
-          <span className={tab === currentTab && "font-semibold"}>{tab}</span>
+          <span className="text-sm font-semibold">{tab}</span>
           <span className="px-[7px] rounded-full bg-pink-300 text-sm text-[#ffff]">
             {postCounts[`${tab.toLowerCase()}Count`]}
           </span>

--- a/src/components/mentoring/post/PostDoneSide.jsx
+++ b/src/components/mentoring/post/PostDoneSide.jsx
@@ -12,7 +12,7 @@ export default function PostDoneSide({ data }) {
           <img
             className="w-56 p-8 rounded-full"
             src={data.writerDTO.profileImage}
-            alt={`작성자 프로필 이미지`}
+            alt="작성자 프로필 이미지"
           ></img>
           <div className="w-full px-4 flex flex-col justify-center space-y-3">
             <h1 className="text-4xl font-bold text-green-700">{data.title}</h1>

--- a/src/components/mentoring/post/PostMenteeSide.jsx
+++ b/src/components/mentoring/post/PostMenteeSide.jsx
@@ -70,7 +70,7 @@ export default function PostMenteeSide({ data }) {
           <img
             className="w-56 p-8 rounded-full"
             src={data.writerDTO.profileImage}
-            alt={`작성자 프로필 이미지`}
+            alt="작성자 프로필 이미지"
           ></img>
           <div className="w-full px-4 flex flex-col justify-center space-y-3">
             <h1 className="text-4xl font-bold text-green-700">{data.title}</h1>

--- a/src/components/mentoring/post/PostMenteeSide.jsx
+++ b/src/components/mentoring/post/PostMenteeSide.jsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 import toast from "react-hot-toast";
 

--- a/src/components/mentoring/post/PostMentorSide.jsx
+++ b/src/components/mentoring/post/PostMentorSide.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, useMutation } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 
 import { deletePostReq, donePostReq } from "../../../apis/mentoring/post";

--- a/src/components/mentoring/post/PostMentorSide.jsx
+++ b/src/components/mentoring/post/PostMentorSide.jsx
@@ -89,7 +89,6 @@ export default function PostMentorSide({ data }) {
           queryClient.invalidateQueries({ queryKey: ["posts"] });
         },
       });
-    navigate("/mentoring/posts");
   };
 
   const handleAcceptClick = () => {

--- a/src/components/mentoring/post/PostMentorSide.jsx
+++ b/src/components/mentoring/post/PostMentorSide.jsx
@@ -31,23 +31,15 @@ export default function PostMentorSide({ data }) {
     }, {})
   );
 
-  const handleCheckBoxChenage = (e) => {
+  const handleCheckBoxChange = (e) => {
     const name = e.target.name;
     if (name === "all") {
-      if (Object.keys(checks).every((val) => checks[val] === true))
-        setChecks(
-          Object.keys(checks).reduce(
-            (acc, key) => ({ ...acc, [key]: false }),
-            {}
-          )
-        );
-      else
-        setChecks(
-          Object.keys(checks).reduce(
-            (acc, key) => ({ ...acc, [key]: true }),
-            {}
-          )
-        );
+      setChecks(
+        Object.keys(checks).reduce(
+          (acc, key) => ({ ...acc, [key]: e.target.checked }),
+          {}
+        )
+      );
     } else {
       setChecks((prev) => ({ ...prev, [name]: !prev[name] }));
     }
@@ -153,7 +145,7 @@ export default function PostMentorSide({ data }) {
           <img
             className="w-56 p-8 rounded-full"
             src={data.writerDTO.profileImage}
-            alt={`작성자 프로필 이미지`}
+            alt="작성자 프로필 이미지"
           ></img>
           <div className="w-full px-4 flex flex-col justify-center space-y-3">
             <h1 className="text-4xl font-bold text-green-700">{data.title}</h1>
@@ -193,7 +185,7 @@ export default function PostMentorSide({ data }) {
                   name="all"
                   className="accent-green-600"
                   checked={Object.values(checks).every((val) => val === true)}
-                  onChange={handleCheckBoxChenage}
+                  onChange={handleCheckBoxChange}
                 />
               </th>
               <th className="p-2 text-left font-medium">Name</th>
@@ -213,7 +205,7 @@ export default function PostMentorSide({ data }) {
                     name={connection.connectionId}
                     className="accent-green-600"
                     checked={checks[connection.connectionId]}
-                    onChange={handleCheckBoxChenage}
+                    onChange={handleCheckBoxChange}
                     disabled={
                       connection.connectionState !== connectionState.AWAIT
                     }

--- a/src/components/mentoring/post/PostSection.jsx
+++ b/src/components/mentoring/post/PostSection.jsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 
 import { uidAtom } from "../../../store";
-import { getPostReq, getUser } from "../../../apis/mentoring/post";
+import { getUser, getPostReq } from "../../../apis/mentoring/post";
 import { userRole, postState } from "../../../constants/mentoring";
 
 import PostDoneSide from "./PostDoneSide";

--- a/src/components/mentoring/posts/PostList.jsx
+++ b/src/components/mentoring/posts/PostList.jsx
@@ -30,8 +30,8 @@ export default function PostList({ category, search }) {
     <div className="flex flex-col">
       {data.pages
         .flatMap((page) => page.data.data)
-        .map((post) => (
-          <PostCard key={`postcard-${post.postId}`} post={post} />
+        .map((post, index) => (
+          <PostCard key={`postcard-${index}`} post={post} />
         ))}
       {isFetchingNextPage && <PostCardSkeletons />}
       <div ref={ref}></div>

--- a/src/components/mentoring/posts/PostsSection.jsx
+++ b/src/components/mentoring/posts/PostsSection.jsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 
+import { authAtom } from "../../../store";
 import { getUser } from "../../../apis/mentoring/post";
 import { useInputsState } from "../../../hooks/useInputsState";
 import { userRole, searchCategory } from "../../../constants/mentoring";
@@ -10,8 +12,6 @@ import Fallback from "../../common/Fallback";
 import Error from "../../common/Error";
 import PostCardSkeletons from "./PostCardSkeletons";
 import PostList from "./PostList";
-import { useAtomValue } from "jotai";
-import { authAtom } from "../../../store";
 import Button from "../../common/Button";
 
 export default function PostsSection() {

--- a/src/constants/mentoring.js
+++ b/src/constants/mentoring.js
@@ -1,6 +1,12 @@
-export const userRole = Object.freeze({ MENTOR: "MENTOR", MENTEE: "MENTEE" });
+export const userRole = Object.freeze({
+  MENTOR: "MENTOR",
+  MENTEE: "MENTEE",
+});
 
-export const postState = Object.freeze({ ACTIVE: "ACTIVE", DONE: "DONE" });
+export const postState = Object.freeze({
+  ACTIVE: "ACTIVE",
+  DONE: "DONE",
+});
 
 export const connectionState = Object.freeze({
   AWAIT: "AWAIT",
@@ -14,4 +20,7 @@ export const searchCategory = Object.freeze({
   INTEREST: "Interest",
 });
 
-export const tabState = Object.freeze({ CONTACT: "Contact", DONE: "Done" });
+export const tabState = Object.freeze({
+  CONTACT: "Contact",
+  DONE: "Done",
+});

--- a/src/constants/mentoring.js
+++ b/src/constants/mentoring.js
@@ -13,3 +13,5 @@ export const searchCategory = Object.freeze({
   WRITER: "Writer",
   INTEREST: "Interest",
 });
+
+export const tabState = Object.freeze({ CONTACT: "Contact", DONE: "Done" });

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -1,8 +1,12 @@
-import { Outlet } from "react-router-dom";
-import Footer from "./Footer";
-import GNB from "./GNB";
-import { getUser } from "../apis/user";
 import { useQuery } from "@tanstack/react-query";
+import { Outlet } from "react-router-dom";
+
+import { getUser } from "../apis/user";
+
+import Loader from "../components/account/atoms/Loader";
+import ScrollToTop from "./ScrollToTop";
+import GNB from "./GNB";
+import Footer from "./Footer";
 
 export default function Layout() {
   const { data, isLoading } = useQuery(["getUser"], getUser);
@@ -13,6 +17,7 @@ export default function Layout() {
 
   return (
     <div className="relative">
+      <ScrollToTop />
       <GNB profileImage={data?.user?.profileImage} />
       <main className="pt-20 pb-20 min-h-screen bg-green-100 flex flex-col">
         <Outlet />

--- a/src/layouts/ScrollToTop.jsx
+++ b/src/layouts/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/pages/mentoring/Dashboard.jsx
+++ b/src/pages/mentoring/Dashboard.jsx
@@ -1,3 +1,16 @@
+import Fallback from "../../components/common/Fallback";
+import Loader from "../../components/common/Loader";
+import Error from "../../components/common/Error";
+import DashboardSection from "../../components/mentoring/dashboard/DashboardSection";
+
 export default function Dashboard() {
-  return <h1>Dashboard</h1>;
+  return (
+    <Fallback
+      Loader={Loader}
+      Error={Error}
+      errorMessage="Failed to load dashboard page"
+    >
+      <DashboardSection />
+    </Fallback>
+  );
 }

--- a/src/pages/mentoring/Posts.jsx
+++ b/src/pages/mentoring/Posts.jsx
@@ -8,7 +8,7 @@ export default function Posts() {
     <Fallback
       Loader={Loader}
       Error={Error}
-      errorMessage="Failed to load mentoring list page"
+      errorMessage="Failed to load list page"
     >
       <PostsSection />
     </Fallback>


### PR DESCRIPTION
## Summary

- 멘토링 대시보드를 구현함
- 멘토링 프로필 모달을 일부 구현함

## Details

#29 TO-DO

```
- 대시보드 구현
```

- 멘토/멘티에 따라 다른 Contact 테이블 구조를 가짐(멘토는 본인글&멘티들, 멘티는 멘토글)

![image](https://github.com/Step3-kakao-tech-campus/Team18_FE/assets/81379968/165a7320-5d8d-4ad6-b4d2-2f8ca22b8958)
![image](https://github.com/Step3-kakao-tech-campus/Team18_FE/assets/81379968/696fd30e-bf86-45a9-9149-9ff96a5f01ea)
![image](https://github.com/Step3-kakao-tech-campus/Team18_FE/assets/81379968/17c3a23c-05d9-4499-a0ff-e51cb0a5b5a7)

- 프로필 모달의 틀을 구현함

![image](https://github.com/Step3-kakao-tech-campus/Team18_FE/assets/81379968/9e653965-d782-417f-a03c-3701d2990e04)

## Issue

- Related #29